### PR TITLE
fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
   #:name (cond [(know-taiwanese? you) "Lîm Tsú-thuàn"]
                [else "Danny"])
   #:focus-on '(PLT networking OS)
-  #:langauges '(racket haskell rust)
+  #:languages '(racket haskell rust)
   #:prover '(arend isabelle coq agda)
   #:learning '(how to make a language based on calculus of inductive construction
                the relationship between Peano Arithmetic, Presburger Arithmetic, and Gödel incompleteness theorem)


### PR DESCRIPTION
languages had the u and the a transposed